### PR TITLE
Fix setup.py long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ setup(
     version='0.1dev',
     packages=['pydashie',],
     license='MIT',
-    long_description=open('README.txt').read(),
+    long_description=open('README.rst').read(),
 )


### PR DESCRIPTION
Fix long_description in setup.py to open the right Readme file.
